### PR TITLE
Reset failed flag back to 0 upon restart.

### DIFF
--- a/checker.js
+++ b/checker.js
@@ -31,6 +31,7 @@ function runCron(delay) {
 
         // If not found, restart and re-stream.
         if (failed > restartIn) {
+            failed = 0;
             return restartParser();
         }
 


### PR DESCRIPTION
There's an issue when `parser` script is restarted but the flag of the `checker` is not reset back to 0, thus making the `parser` restart indefinitely.